### PR TITLE
rename @background-color to @gray-very-dark

### DIFF
--- a/styles/atom.less
+++ b/styles/atom.less
@@ -4,10 +4,10 @@ html {
     height: 100%;
     min-height: 100%;
     padding: 6px;
-    background: @background-color;
+    background: @gray-very-dark;
 }
 body {
-    background: @background-color;
+    background: @gray-very-dark;
     overflow: hidden;
     height: 100%;
     min-height: 100%;
@@ -20,7 +20,7 @@ body {
     box-sizing: border-box;
 }
 atom-workspace {
-    background-color: @background-color;
+    background-color: @gray-very-dark;
     border: 2px solid @cyan-light;
     border-radius: 4px;
 
@@ -28,7 +28,7 @@ atom-workspace {
 
 atom-workspace-axis.vertical {
     z-index: 2;
-    box-shadow: -2px 0px 10px 5px @background-color;
+    box-shadow: -2px 0px 10px 5px @gray-very-dark;
 }
 .scrollbars-visible-always {
     /deep/::-webkit-scrollbar {

--- a/styles/buttons.less
+++ b/styles/buttons.less
@@ -22,12 +22,12 @@
 .btn,
 .btn.icon {
     background-color: @text-color;
-    color: @background-color;
+    color: @gray-very-dark;
     font-weight: bold;
     border-radius: 3px;
     &:hover {
         background-color: @white;
-        color: @background-color;
+        color: @gray-very-dark;
     }
 }
 .btn.btn-xs {
@@ -41,7 +41,7 @@
 }
 .btn.btn-primary {
     background-color: @text-color;
-    color: @background-color;
+    color: @gray-very-dark;
     &:hover {
         background-color: @white;
     }
@@ -51,7 +51,7 @@
 }
 .btn.btn-info {
     background-color: @text-color;
-    color: @background-color;
+    color: @gray-very-dark;
     &:hover {
         background-color: @white;
     }
@@ -61,14 +61,14 @@
 }
 .btn.btn-success {
     background-color: @text-color-success;
-    color: @background-color;
+    color: @gray-very-dark;
     &:hover {
         background-color: @white;
     }
 }
 .btn.btn-success.selected {
     background-color: @text-color-success;
-    color: @background-color;
+    color: @gray-very-dark;
     &:hover {
         background-color: @white;
     }
@@ -84,7 +84,7 @@
 }
 .btn.btn-error {
     background-color: @text-color-error;
-    color: @background-color;
+    color: @gray-very-dark;
     &:hover {
         background-color: @white;
     }

--- a/styles/lists.less
+++ b/styles/lists.less
@@ -6,7 +6,7 @@
 .list-group {
     &.selected {
         &::before {
-            color: @background-color;
+            color: @gray-very-dark;
             background-color: @text-color;
         }
     }
@@ -14,10 +14,10 @@
 
     }
     .list-item.selected {
-        color: @background-color;
+        color: @gray-very-dark;
         background-color: @text-color;
         &::before {
-            color: @background-color;
+            color: @gray-very-dark;
             background-color: @text-color;
         }
     }
@@ -25,7 +25,7 @@
 
 .list-tree {
     .selected {
-        color: @background-color;
+        color: @gray-very-dark;
         &::before {
             background-color: @text-color;
         }
@@ -38,7 +38,7 @@
         padding-left: 0 !important;
     }
     .selected {
-        color: @background-color;
+        color: @gray-very-dark;
         &::before {
             background-color: @text-color;
         }
@@ -46,10 +46,10 @@
 }
 
 .list-item.selected {
-    color: @background-color;
+    color: @gray-very-dark;
     background-color: @text-color;
     &::before {
-        color: @background-color;
+        color: @gray-very-dark;
         background-color: @text-color;
     }
 }

--- a/styles/modals.less
+++ b/styles/modals.less
@@ -6,7 +6,7 @@ atom-panel.modal {
     border: 2px solid @text-color;
     border-radius: 3px;
 
-    background: @background-color;
+    background: @gray-very-dark;
 
 
 }

--- a/styles/panels.less
+++ b/styles/panels.less
@@ -56,7 +56,7 @@ atom-panel.left {
         top: 8px;
         right: 4px;
         line-height: 50px;
-        color: @background-color;
+        color: @gray-very-dark;
         left: 12px;
         border-radius: 4px;
         font-size: 32px;

--- a/styles/panes.less
+++ b/styles/panes.less
@@ -8,9 +8,9 @@
 }
 atom-pane-container {
     atom-pane {
-        background-color: @background-color;
+        background-color: @gray-very-dark;
         &:focus {
-            background-color: @background-color;
+            background-color: @gray-very-dark;
         }
         .item-views {
             z-index: 0;
@@ -19,7 +19,7 @@ atom-pane-container {
             margin: 0 14px 0 0;
             border: 2px solid @cyan-light;
             border-radius: 3px;
-            background-color: @background-color;
+            background-color: @gray-very-dark;
         }
     }
     atom-pane.active {

--- a/styles/text.less
+++ b/styles/text.less
@@ -33,24 +33,24 @@
 }
 .highlight {
     background-color: @text-color-highlight;
-    color: @background-color;
+    color: @gray-very-dark;
 }
 .highlight-info {
     background-color: @text-color-info;
-    color: @background-color;
+    color: @gray-very-dark;
 
 }
 .highlight-success {
     background-color: @text-color-success;
-    color: @background-color;
+    color: @gray-very-dark;
 }
 .highlight-warning {
     background-color: @text-color-warning;
-    color: @background-color;
+    color: @gray-very-dark;
 }
 .highlight-error {
     background-color: @text-color-error;
-    color: @background-color;
+    color: @gray-very-dark;
 }
 
 /*

--- a/styles/ui-variables.less
+++ b/styles/ui-variables.less
@@ -7,7 +7,7 @@
 @medium-green: #3c6e65;
 @alt-green: #16ab8d;
 @dark-green: #31564f;
-@background-color: #1c1c1c;
+@gray-very-dark: #1c1c1c;
 @white: #ffffff;
 @black: #000000;
 
@@ -28,7 +28,7 @@
 @text-color: @cyan-light;
 @text-color-subtle: @cyan-dark;
 @text-color-highlight: @alt-green;
-@text-color-selected: @background-color;
+@text-color-selected: @gray-very-dark;
 
 @text-color-info: @green;
 @text-color-success: @bright-green; /* turqoise */
@@ -52,12 +52,12 @@
 
 @background-color-highlight: rgba(255, 255, 255, 1);
 @background-color-selected: @cyan-light;
-@app-background-color: @background-color;
+@app-background-color: @gray-very-dark;
 
 // Base colors
 
-@base-background-color: @background-color;
-@base-border-color: @background-color;
+@base-background-color: @gray-very-dark;
+@base-border-color: @gray-very-dark;
 
 // Component colors
 
@@ -67,7 +67,7 @@
 @input-background-color: #212224;
 @input-border-color: @base-border-color;
 
-@tool-panel-background-color: @background-color;
+@tool-panel-background-color: @gray-very-dark;
 @tool-panel-border-color: @base-border-color;
 @inset-panel-background-color: #161719;
 @inset-panel-border-color: @base-border-color;
@@ -80,14 +80,14 @@
 @button-background-color-hover: lighten(@button-background-color, 5%);
 @button-background-color-selected: #5c6064;
 @button-border-color: @base-border-color;
-@tab-bar-background-color: @background-color;
+@tab-bar-background-color: @gray-very-dark;
 @tab-bar-border-color: #000000;
 @tab-background-color: #000000;
 @tab-background-color-active: #000000;
 @tab-border-color: #000000;
 
-@tree-view-background-color: @background-color;
-@tree-view-border-color: @background-color;
+@tree-view-background-color: @gray-very-dark;
+@tree-view-border-color: @gray-very-dark;
 
 // Site colors
 


### PR DESCRIPTION
The [github](https://atom.io/packages/github) integration package that Atom ships with defines `@background-color` at `github/styles/review.less`.

Because of scope pollution this causes a `Recursive variable definition for @background-color` error which in turn causes [this error](https://github.com/atom/github/issues/978) that breaks the atom stylesheets. Renaming the variable to something else avoids this problem.